### PR TITLE
Span attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .python-version
 *.egg-info
 .vscode
+.venv

--- a/src/pytest_opentelemetry/instrumentation.py
+++ b/src/pytest_opentelemetry/instrumentation.py
@@ -21,6 +21,7 @@ from .resource import CodebaseResourceDetector
 
 tracer = trace.get_tracer('pytest-opentelemetry')
 
+PYTEST_SPAN_TYPE = "pytest.span_type"
 
 class OpenTelemetryPlugin:
     """A pytest plugin which produces OpenTelemetry spans around test sessions and
@@ -52,6 +53,9 @@ class OpenTelemetryPlugin:
         self.session_span = tracer.start_span(
             self.session_name,
             context=self.trace_parent,
+            attributes={
+                PYTEST_SPAN_TYPE: "run",
+            }
         )
 
     def pytest_sessionfinish(self, session: Session) -> None:
@@ -65,8 +69,9 @@ class OpenTelemetryPlugin:
             attributes = {
                 SpanAttributes.CODE_FILEPATH: filepath,
                 SpanAttributes.CODE_FUNCTION: item.name,
-                "test.id": item.nodeid,
-                "test.keywords": str(item.keywords),
+                "pytest.nodeid": item.nodeid,
+                "pytest.keywords": str(item.keywords),
+                PYTEST_SPAN_TYPE: "test",
             }
             # In some cases like tavern, line_number can be 0
             if line_number:

--- a/src/pytest_opentelemetry/instrumentation.py
+++ b/src/pytest_opentelemetry/instrumentation.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Generator, Optional
 
 import pytest
@@ -45,7 +46,7 @@ class OpenTelemetryPlugin:
         configurator.resource_detectors.append(OTELResourceDetector())
         configurator.configure()
 
-    session_name: str = 'test run'
+    session_name: str = os.environ.get('PYTEST_RUN_NAME', 'test run')
 
     def pytest_sessionstart(self, session: Session) -> None:
         self.session_span = tracer.start_span(

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -21,23 +21,34 @@ def test_simple_pytest_functions(
     spans = span_recorder.spans_by_name()
     assert len(spans) == 2 + 1
 
-    assert 'test run' in spans
+    span = spans['test run']
+    assert span.status.is_ok
+    assert span.attributes
+    assert span.attributes["pytest.span_type"] == "run"
 
-    span = spans['test_simple_pytest_functions.py::test_one']
+    span = spans['test_one']
     assert span.kind == SpanKind.INTERNAL
     assert span.status.is_ok
     assert span.attributes
     assert span.attributes['code.function'] == 'test_one'
     assert span.attributes['code.filepath'] == 'test_simple_pytest_functions.py'
-    assert span.attributes['code.lineno'] == '0'
+    assert 'code.lineno' not in span.attributes
+    assert span.attributes["pytest.span_type"] == "test"
+    assert (
+        span.attributes["pytest.nodeid"] == "test_simple_pytest_functions.py::test_one"
+    )
 
-    span = spans['test_simple_pytest_functions.py::test_two']
+    span = spans['test_two']
     assert span.kind == SpanKind.INTERNAL
     assert span.status.is_ok
     assert span.attributes
     assert span.attributes['code.function'] == 'test_two'
     assert span.attributes['code.filepath'] == 'test_simple_pytest_functions.py'
-    assert span.attributes['code.lineno'] == '3'
+    assert span.attributes['code.lineno'] == 3
+    assert span.attributes["pytest.span_type"] == "test"
+    assert (
+        span.attributes["pytest.nodeid"] == "test_simple_pytest_functions.py::test_two"
+    )
 
 
 def test_failures_and_errors(pytester: Pytester, span_recorder: SpanRecorder) -> None:
@@ -59,29 +70,30 @@ def test_failures_and_errors(pytester: Pytester, span_recorder: SpanRecorder) ->
     spans = span_recorder.spans_by_name()
     assert len(spans) == 3 + 1
 
-    assert 'test run' in spans
+    span = spans['test run']
+    assert not span.status.is_ok
 
-    span = spans['test_failures_and_errors.py::test_one']
+    span = spans['test_one']
     assert span.status.is_ok
 
-    span = spans['test_failures_and_errors.py::test_two']
+    span = spans['test_two']
     assert not span.status.is_ok
     assert span.attributes
     assert span.attributes['code.function'] == 'test_two'
     assert span.attributes['code.filepath'] == 'test_failures_and_errors.py'
-    assert span.attributes['code.lineno'] == '3'
+    assert span.attributes['code.lineno'] == 3
     assert 'exception.stacktrace' not in span.attributes
     assert len(span.events) == 1
     event = span.events[0]
     assert event.attributes
     assert event.attributes['exception.type'] == 'AssertionError'
 
-    span = spans['test_failures_and_errors.py::test_three']
+    span = spans['test_three']
     assert not span.status.is_ok
     assert span.attributes
     assert span.attributes['code.function'] == 'test_three'
     assert span.attributes['code.filepath'] == 'test_failures_and_errors.py'
-    assert span.attributes['code.lineno'] == '6'
+    assert span.attributes['code.lineno'] == 6
     assert 'exception.stacktrace' not in span.attributes
     assert len(span.events) == 1
     event = span.events[0]
@@ -120,16 +132,16 @@ def test_failures_in_fixtures(pytester: Pytester, span_recorder: SpanRecorder) -
 
     assert 'test run' in spans
 
-    span = spans['test_failures_in_fixtures.py::test_one']
+    span = spans['test_one']
     assert span.status.is_ok
 
-    span = spans['test_failures_in_fixtures.py::test_two']
+    span = spans['test_two']
     assert not span.status.is_ok
 
-    span = spans['test_failures_in_fixtures.py::test_three']
+    span = spans['test_three']
     assert not span.status.is_ok
 
-    span = spans['test_failures_in_fixtures.py::test_four']
+    span = spans['test_four']
     assert not span.status.is_ok
 
 
@@ -153,14 +165,26 @@ def test_parametrized_tests(pytester: Pytester, span_recorder: SpanRecorder) -> 
 
     assert 'test run' in spans
 
-    span = spans['test_parametrized_tests.py::test_one[world]']
+    span = spans['test_one[world]']
     assert span.status.is_ok
+    assert span.attributes
+    assert (
+        span.attributes["pytest.nodeid"]
+        == "test_parametrized_tests.py::test_one[world]"
+    )
 
-    span = spans['test_parametrized_tests.py::test_one[people]']
+    span = spans['test_one[people]']
     assert span.status.is_ok
+    assert span.attributes
+    assert (
+        span.attributes["pytest.nodeid"]
+        == "test_parametrized_tests.py::test_one[people]"
+    )
 
-    span = spans['test_parametrized_tests.py::test_two']
+    span = spans['test_two']
     assert span.status.is_ok
+    assert span.attributes
+    assert span.attributes["pytest.nodeid"] == "test_parametrized_tests.py::test_two"
 
 
 def test_class_tests(pytester: Pytester, span_recorder: SpanRecorder) -> None:
@@ -181,11 +205,19 @@ def test_class_tests(pytester: Pytester, span_recorder: SpanRecorder) -> None:
 
     assert 'test run' in spans
 
-    span = spans['test_class_tests.py::TestThings::test_one']
+    span = spans['test_one']
     assert span.status.is_ok
+    assert span.attributes
+    assert (
+        span.attributes["pytest.nodeid"] == "test_class_tests.py::TestThings::test_one"
+    )
 
-    span = spans['test_class_tests.py::TestThings::test_two']
+    span = spans['test_two']
     assert span.status.is_ok
+    assert span.attributes
+    assert (
+        span.attributes["pytest.nodeid"] == "test_class_tests.py::TestThings::test_two"
+    )
 
 
 def test_test_spans_are_children_of_sessions(
@@ -203,7 +235,7 @@ def test_test_spans_are_children_of_sessions(
     assert len(spans) == 2
 
     test_run = spans['test run']
-    test = spans['test_test_spans_are_children_of_sessions.py::test_one']
+    test = spans['test_one']
 
     assert test_run.context.trace_id
     assert test.context.trace_id == test_run.context.trace_id
@@ -232,7 +264,7 @@ def test_spans_within_tests_are_children_of_test_spans(
     assert len(spans) == 3
 
     test_run = spans['test run']
-    test = spans['test_spans_within_tests_are_children_of_test_spans.py::test_one']
+    test = spans['test_one']
     inner = spans['inner']
 
     assert test_run.context.trace_id


### PR DESCRIPTION
Sorry for the delay.

I created https://github.com/Yamakaky/tests-tavern to have a test run with both tavern and pytest, maybe it can be added in your tests. For each commit here, I'll add a collector.log so that we can see the attributes generated.

Fixes #11

Implemented:
- [X] Configurable root span name via env variable
  - [ ] maybe other means, different env variable ?
- [X] Use node.id in an attribute and node.name in span name
- [X] Set code.function to item.name
- [X] Optional code.lineno
- [ ] record tavern test parameters as attributes
- [x] Create attributes to differentiate main span and test span
- [x] Set test run status