### PR TITLE
Add force flush before exit

### DIFF
--- a/src/pytest_opentelemetry/instrumentation.py
+++ b/src/pytest_opentelemetry/instrumentation.py
@@ -172,5 +172,5 @@ class XdistOpenTelemetryPlugin(OpenTelemetryPlugin):
         with trace.use_span(self.session_span, end_on_exit=False):
             propagate.inject(node.workerinput)
 
-    def pytest_xdist_node_collection_finished(node, ids):
+    def pytest_xdist_node_collection_finished(node, ids):  # pragma: no cover
         super().try_force_flush()

--- a/src/pytest_opentelemetry/instrumentation.py
+++ b/src/pytest_opentelemetry/instrumentation.py
@@ -63,10 +63,10 @@ class OpenTelemetryPlugin:
     def pytest_configure(self, config: Config) -> None:
         self.trace_parent = self.get_trace_parent(config)
 
+        # This can't be tested both ways in one process
         if config.getoption('--export-traces'):  # pragma: no cover
             OpenTelemetryContainerDistro().configure()
 
-        # This can't be tested both ways in one process
         configurator = OpenTelemetryContainerConfigurator()
         configurator.resource_detectors.append(CodebaseResourceDetector())
         configurator.resource_detectors.append(OTELResourceDetector())

--- a/src/pytest_opentelemetry/instrumentation.py
+++ b/src/pytest_opentelemetry/instrumentation.py
@@ -66,6 +66,7 @@ class OpenTelemetryPlugin:
         if config.getoption('--export-traces'):  # pragma: no cover
             OpenTelemetryContainerDistro().configure()
 
+        # This can't be tested both ways in one process
         configurator = OpenTelemetryContainerConfigurator()
         configurator.resource_detectors.append(CodebaseResourceDetector())
         configurator.resource_detectors.append(OTELResourceDetector())
@@ -86,8 +87,8 @@ class OpenTelemetryPlugin:
             StatusCode.ERROR if self.has_error else StatusCode.OK
         )
 
-        self.try_force_flush()
         self.session_span.end()
+        self.try_force_flush()
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item: Item) -> Generator[None, None, None]:


### PR DESCRIPTION
Call force flush before pytest exits (to ensure all spans are correctly exported).

It was observed when running a large test suite on ephemeral workers that some spans were being lost; this should resolve the issue.