### PR TITLE
Add trace-per-test option

### DIFF
--- a/src/pytest_opentelemetry/plugin.py
+++ b/src/pytest_opentelemetry/plugin.py
@@ -26,16 +26,25 @@ def pytest_addoption(parser: Parser) -> None:
             'trace.  If it is omitted, this test run will start a new trace.'
         ),
     )
+    group.addoption(
+        "--trace-per-test",
+        action="store_true",
+        default=False,
+        help="Creates a separate trace per test instead of a trace for the test run",
+    )
 
 
 def pytest_configure(config: Config) -> None:
     # pylint: disable=import-outside-toplevel
     from pytest_opentelemetry.instrumentation import (
         OpenTelemetryPlugin,
+        PerTestOpenTelemetryPlugin,
         XdistOpenTelemetryPlugin,
     )
 
-    if config.pluginmanager.has_plugin("xdist"):
+    if config.getvalue('--trace-per-test'):
+        config.pluginmanager.register(PerTestOpenTelemetryPlugin())
+    elif config.pluginmanager.has_plugin("xdist"):
         config.pluginmanager.register(XdistOpenTelemetryPlugin())
     else:
         config.pluginmanager.register(OpenTelemetryPlugin())


### PR DESCRIPTION
Trace-per-run is not always great e.g. it's confusing to have a sequence of tests which are normally independent, and then the layout changes when xdist is involved as you get concurrent spans (one for each worker).

This also causes issues in the more bare-bone / simplistic frontends / final collectors (e.g. OpenTelemetry Desktop) as they might not have the most complex folding and filtering features. OTD for instance has little to no ability to manipulate spans, but it is possible to select individual traces and see just that trace's spans (in fact that's the only mode).

As a result, generating a separate trace per test per run allows easier classification, observation, and manipulation of the trace. I would also assume in the long term it allows comparing the traces of the same test in order to get insight into their evolution, something which is more difficult with trace-per-run.

Finally an other issue with trace-per-run, mostly in long suites, is that the trace remains incomplete (tools complain of missing parent spans) until the entire run has completed, making observation during run more difficult.

Fixes #33